### PR TITLE
Add serverActions body size limit to Next.js config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
     remotePatterns: [
@@ -6,6 +7,11 @@ const nextConfig = {
         hostname: '**',
       },
     ],
+  },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '10mb',
+    },
   },
 };
 


### PR DESCRIPTION
Set the experimental serverActions bodySizeLimit to 10mb in next.config.mjs to allow larger request bodies for server actions.